### PR TITLE
camera driver update script for apple laptops running Ubuntu

### DIFF
--- a/hello_world.sh
+++ b/hello_world.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+echo Hello Bada

--- a/simple-interest.sh
+++ b/simple-interest.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+echo "Welcome to the interest rate calculator"
+
+echo -n "Enter the principal amount :"
+
+read principal
+
+echo -n "Enter the number of deposit years :"
+
+read years
+
+echo -n "Enter the rate of interest :"
+
+read rate
+
+interest_earned=$(expr $principal \* $years \* $rate / 100)
+
+echo -n "You will earn:"
+echo -n "$interest_earned"
+echo -n " "

--- a/update_camera_driver_script.sh
+++ b/update_camera_driver_script.sh
@@ -1,0 +1,27 @@
+cd ~
+
+current_directory=$(pwd)
+
+echo -n $current_directory
+
+cd facetimehd-firmware
+
+make
+
+sudo make install
+
+cd ..
+
+sudo apt-get install kmod libssl-dev checkinstall
+
+cd bcwc_pcie
+
+make
+
+sudo make install
+
+sudo depomod
+
+sudo modprobe facetimehd
+
+sudo reboot


### PR DESCRIPTION
This script runs in Macbook Air 2017 as of July 04, 2022.
Issue: 
Web camera did not work when I migrated my laptop's OS to Ubuntu from MacOS. The bash script updates the driver.